### PR TITLE
Updated elgohr/Publish-Docker-Github-Action to a supported version (v5)

### DIFF
--- a/.github/workflows/docker.yml.disabled
+++ b/.github/workflows/docker.yml.disabled
@@ -19,7 +19,7 @@ jobs:
       run: git fetch --prune --unshallow
 
     - name: Publish to Registry
-      uses: elgohr/Publish-Docker-Github-Action@master
+      uses: elgohr/Publish-Docker-Github-Action@v5
       with:
         name: micro/micro
         username: ${{ secrets.DOCKER_USERNAME }}

--- a/.github/workflows/integration-k8s.yml.disabled
+++ b/.github/workflows/integration-k8s.yml.disabled
@@ -20,7 +20,7 @@ jobs:
       uses: engineerd/setup-kind@v0.3.0
 
     - name: Publish to Registry
-      uses: elgohr/Publish-Docker-Github-Action@master
+      uses: elgohr/Publish-Docker-Github-Action@v5
       with:
         name: micro/micro
         username: ${{ secrets.DOCKER_USERNAME }}

--- a/.github/workflows/staging.yml
+++ b/.github/workflows/staging.yml
@@ -16,7 +16,7 @@ jobs:
       run: git fetch --prune --unshallow
 
     - name: Publish to Registry
-      uses: elgohr/Publish-Docker-Github-Action@master
+      uses: elgohr/Publish-Docker-Github-Action@v5
       with:
         name: micro/micro
         username: ${{ secrets.DOCKER_USERNAME }}


### PR DESCRIPTION
elgohr/Publish-Docker-Github-Action@master is not supported anymore